### PR TITLE
Update presets for 6.0

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -542,7 +542,7 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "fw_p_yaw",
-                value: 20
+                value: 50
             },
             {
                 key: "fw_i_yaw",
@@ -550,27 +550,11 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "fw_d_yaw",
-                value: 0
+                value: 20
             },
             {
                 key: "fw_ff_yaw",
-                value: 100
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 7
-            },
-            {
-                key: "imu_acc_ignore_slope",
-                value: 4
-            },
-            {
-                key: "imu_dcm_kp",
-                value: 1000
-            },
-            {
-                key: "imu_dcm_ki",
-                value: 0
+                value: 255
             },
             {
                 key: "airmode_type",
@@ -782,22 +766,6 @@ helper.defaultsDialog = (function () {
             {
                 key: "fw_ff_yaw",
                 value: 100
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 9
-            },
-            {
-                key: "imu_acc_ignore_slope",
-                value: 5
-            },
-            {
-                key: "imu_dcm_kp",
-                value: 1000
-            },
-            {
-                key: "imu_dcm_ki",
-                value: 0
             },
             {
                 key: "airmode_type",


### PR DESCRIPTION
Removed IMU settings as the new Firmware Defaults will match MR and FW.  Added new YAW Default PIDs for better Turn-Assist control in nav modes with stab yaw used and more authority in acro